### PR TITLE
Only close DB if opened

### DIFF
--- a/main.go
+++ b/main.go
@@ -318,9 +318,11 @@ func main() {
 	close(results)
 	<-resultDone
 
-	err := db.Close()
-	if err != nil {
-		log.Errorf("Error closing DB: %v", err)
+	if db != nil {
+		err := db.Close()
+		if err != nil {
+			log.Errorf("Error closing DB: %v", err)
+		}
 	}
 
 	// Exit immediately if the program was interrupted.


### PR DESCRIPTION
This PR fixes an issue introduced by my previous PR when no database is used:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x410d6f2]

goroutine 1 [running]:
main.(*DB).Close(0x0, 0x0, 0xc42007c300)
	/Users/mafredri/Golang/src/github.com/opennota/findimagedupes/db.go:180 +0x22
main.main()
	/Users/mafredri/Golang/src/github.com/opennota/findimagedupes/main.go:321 +0xca3
```